### PR TITLE
Fix ERROR: No ola.jar found in /deployments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
 							<build>
 								<from>${docker.from}</from>
 								<assembly>
-									<basedir>/app</basedir>
+									<basedir>/deployments</basedir>
 									<descriptorRef>artifact</descriptorRef>
 								</assembly>
 								<env>


### PR DESCRIPTION
When using `mvn clean package docker:build …`.